### PR TITLE
fix: Correctly handle indentation for nested json

### DIFF
--- a/test/bigint.test.ts
+++ b/test/bigint.test.ts
@@ -5,12 +5,14 @@
 import { JSONB as JSB } from "index";
 
 describe(`Testing bigint support`, function () {
-    const input = `{"big":9223372036854775807,"small":123}`;
+    const input = `{"big":9223372036854775807,"small":123,"decimal":51.971428571428575}`;
 
     it(`Should show classic JSON.parse lacks bigint support`, function (done) {
         const obj = JSON.parse(input);
         // string from small int
         expect(obj.small.toString()).toEqual(`123`);
+        // string from small float
+        expect(obj.decimal.toString()).toEqual(`51.971428571428575`);
         // string from big int
         expect(obj.big.toString()).not.toEqual(`9223372036854775807`);
 
@@ -24,6 +26,8 @@ describe(`Testing bigint support`, function () {
         const obj = JSONB.parse(input);
         // string from small int
         expect(obj.small.toString()).toEqual(`123`);
+        // string from small float
+        expect(obj.decimal.toString()).toEqual(`51.971428571428575`);
         // string from big int
         expect(obj.big.toString()).toEqual(`9223372036854775807`);
         // instanceof big int

--- a/test/indent-stringify.test.ts
+++ b/test/indent-stringify.test.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/naming-convention */
+import { JSONB as JSB } from "index";
+
+describe(`Testing indentation: stringify`, function () {
+    if (typeof BigInt === `undefined`) {
+        console.log(`No native BigInt`);
+        return;
+    }
+    it(`should correctly indent nested objects`, function (done) {
+        const JSONB = JSB;
+        const obj = {
+            // We cannot use n-literals - otherwise older NodeJS versions fail on this test
+            big: eval(`123456789012345678901234567890n`),
+            small: -42,
+            bigConstructed: BigInt(1),
+            smallConstructed: Number(2),
+            array: [
+                {
+                    key: 1,
+                },
+            ],
+            object: {
+                key: `value`,
+                nestedObject: {
+                    key: 1,
+                },
+            },
+        };
+        // string from small int
+        expect(obj.small.toString()).toEqual(`-42`);
+        // string from big int
+        expect(obj.big.toString()).toEqual(`123456789012345678901234567890`);
+        // typeof big int
+        expect(typeof obj.big).toEqual(`bigint`);
+
+        const output = JSONB.stringify(obj, null, 4);
+        expect(output).toEqual(
+            `{\n` +
+                `    "big": 123456789012345678901234567890,\n` +
+                `    "small": -42,\n` +
+                `    "bigConstructed": 1,\n` +
+                `    "smallConstructed": 2,\n` +
+                `    "array": [\n` +
+                `        {\n` +
+                `            "key": 1\n` +
+                `        }\n` +
+                `    ],\n` +
+                `    "object": {\n` +
+                `        "key": "value",\n` +
+                `        "nestedObject": {\n` +
+                `            "key": 1\n` +
+                `        }\n` +
+                `    }\n` +
+                `}`,
+        );
+        done();
+    });
+});


### PR DESCRIPTION
Previously the recursive call to sStringify would take
already stringified nested object and append only one indent
to account for it being a child of another one.

This is incorrect

If we are given a nested object string and are placing it
as a child of another object, we need to prepend the indent
string to each of the lines of the nested object string
apart from the open and end tokens (e.g. so anything matching
\{}[]\)

This is a naive fix